### PR TITLE
Give a proper name to package and lib in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "rust"
+name = "sp_backend"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "rust"
+name = "sp_backend"
 crate-type = ["lib", "staticlib", "cdylib"]
 # crate-type = ["lib"]
 


### PR DESCRIPTION
I noticed that the package didn't have a proper name when I tried to import it as a dependency and it kept failing. I proposed the most straightforward, but obviously the name can be different.