### PR TITLE
setup with mnemonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ serde = { version = "1.0.188", features = ["derive"] }
 turbosql = "0.8.0"
 bitcoin = { version = "0.29.2", features = ["serde"] }
 once_cell = "1.18.0"
+bip39 = "2.0.0"
+hex = "0.4.3"


### PR DESCRIPTION
Refactoring of 3a9b0eba9543d2dc5dd046aefe3099958fc6f82d without the scan_height bug fix.

Allow to setup a new sp_client with a mnemonic (setup with a couple scan/spend key is still possible).

The sp_client is setup with scan and spend both *private* keys instead of scan_priv/spend_pub to stay consistent with setuping with mnemonic and make spending from the app easier. This should eventually become an option (watch-only wallet).