### PR TITLE
Implement basic spending function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ electrum-client = { git = "https://github.com/cygnet3/rust-electrum-client", bra
 anyhow = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-bitcoin = { version = "0.31.1", features = ["serde"] }
+bitcoin = { version = "0.31.1", features = ["serde", "rand", "base64"] }
 once_cell = "1.18.0"
 bip39 = { version = "2.0.0", features = ["rand"] }
 hex = "0.4.3"

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,9 @@ use flutter_rust_bridge::StreamSink;
 use crate::{
     constants::{LogEntry, SyncStatus, WalletType},
     nakamotoclient,
-    spclient::{derive_keys_from_mnemonic, OwnedOutput, ScanProgress, SpClient, SpendKey},
+    spclient::{
+        derive_keys_from_mnemonic, OwnedOutput, Psbt, Recipient, ScanProgress, SpClient, SpendKey,
+    },
     stream::{self, loginfo},
 };
 
@@ -217,3 +219,10 @@ pub fn get_outputs(path: String, label: String) -> Result<Vec<OwnedOutput>, Stri
 
     Ok(sp_client.list_outpoints())
 }
+
+pub fn create_new_psbt(inputs: Vec<OwnedOutput>, recipients: Vec<Recipient>) -> Result<String, String> {
+    let psbt = SpClient::create_new_psbt(inputs, recipients).map_err(|e| e.to_string())?;
+
+    Ok(psbt.to_string())
+}
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -226,3 +226,16 @@ pub fn create_new_psbt(inputs: Vec<OwnedOutput>, recipients: Vec<Recipient>) -> 
     Ok(psbt.to_string())
 }
 
+pub fn fill_sp_outputs(path: String, label: String, psbt: String) -> Result<String, String> {
+    let sp_client: SpClient = match SpClient::try_init_from_disk(label, path) {
+        Ok(s) => s,
+        Err(_) => return Err("Wallet not found".to_owned())
+    };
+
+    let mut psbt = Psbt::from_str(&psbt).map_err(|e| e.to_string())?;
+
+    sp_client.fill_sp_outputs(&mut psbt).map_err(|e| e.to_string())?;
+
+    Ok(psbt.to_string())
+}
+

--- a/src/api.rs
+++ b/src/api.rs
@@ -226,6 +226,15 @@ pub fn create_new_psbt(inputs: Vec<OwnedOutput>, recipients: Vec<Recipient>) -> 
     Ok(psbt.to_string())
 }
 
+// payer is an address, either Silent Payment or not
+pub fn add_fee_for_fee_rate(psbt: String, fee_rate: u32, payer: String) -> Result<String, String> {
+    let mut psbt = Psbt::from_str(&psbt).map_err(|e| e.to_string())?;
+
+    SpClient::set_fees(&mut psbt, fee_rate, payer).map_err(|e| e.to_string())?;
+
+    Ok(psbt.to_string())
+}
+
 pub fn fill_sp_outputs(path: String, label: String, psbt: String) -> Result<String, String> {
     let sp_client: SpClient = match SpClient::try_init_from_disk(label, path) {
         Ok(s) => s,

--- a/src/api.rs
+++ b/src/api.rs
@@ -239,3 +239,19 @@ pub fn fill_sp_outputs(path: String, label: String, psbt: String) -> Result<Stri
     Ok(psbt.to_string())
 }
 
+pub fn sign_psbt(path: String, label: String, psbt: String, finalize: bool) -> Result<String, String> {
+    let sp_client: SpClient = match SpClient::try_init_from_disk(label, path) {
+        Ok(s) => s,
+        Err(_) => return Err("Wallet not found".to_owned())
+    };
+
+    let psbt = Psbt::from_str(&psbt).map_err(|e| e.to_string())?;
+
+    let mut signed = sp_client.sign_psbt(psbt).map_err(|e| e.to_string())?;
+
+    if finalize {
+        SpClient::finalize_psbt(&mut signed).map_err(|e| e.to_string())?;
+    }
+
+    Ok(signed.to_string())
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,13 @@ pub enum WalletType {
     ReadOnly(SecretKeyString, PublicKeyString),
 }
 
+pub const PSBT_SP_PREFIX: &str = "sp";
+pub const PSBT_SP_SUBTYPE: u8 = 0;
+pub const PSBT_SP_TWEAK_KEY: &str = "tweak";
+pub const PSBT_SP_ADDRESS_KEY: &str = "address";
+
+pub const NUMS: &str = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+
 pub struct LogEntry {
     // pub time_millis: i64,
     // pub level: i32,

--- a/src/spclient.rs
+++ b/src/spclient.rs
@@ -1,15 +1,46 @@
-use bip39::Mnemonic;
-use bitcoin::{bip32::{DerivationPath, Xpriv}, secp256k1::{constants::SECRET_KEY_SIZE, PublicKey, Secp256k1, SecretKey}, Network};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
+
+use bip39::{
+    rand::{self, seq::SliceRandom},
+    Mnemonic,
+};
+
+use bitcoin::psbt::{raw, Input, Output};
+use bitcoin::{
+    bip32::{DerivationPath, Xpriv},
+    consensus::{deserialize, serialize},
+    hashes::hex::FromHex,
+    key::TapTweak,
+    psbt::PsbtSighashType,
+    secp256k1::{
+        constants::SECRET_KEY_SIZE, Keypair, Message, PublicKey, Scalar, Secp256k1, SecretKey,
+        ThirtyTwoByteHash,
+    },
+    sighash::{Prevouts, SighashCache},
+    taproot::Signature,
+    Address, Amount, Network, ScriptBuf, TapLeafHash, Transaction, TxIn, TxOut, Witness,
+};
 use nakamoto::common::bitcoin::OutPoint;
-use serde::{Serialize, Deserialize};
+
+use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+
 use silentpayments::receiving::Receiver;
-use std::{str::FromStr, collections::HashMap};
+use silentpayments::sending::SilentPaymentAddress;
+use silentpayments::utils as sp_utils;
 
-use anyhow::Result;
+use anyhow::{Error, Result};
 
+use crate::constants::{
+    NUMS, PSBT_SP_ADDRESS_KEY, PSBT_SP_PREFIX, PSBT_SP_SUBTYPE, PSBT_SP_TWEAK_KEY,
+};
 use crate::{db::FileWriter, stream::loginfo};
+
+pub use bitcoin::psbt::Psbt;
 
 pub struct ScanProgress {
     pub start: u32,
@@ -26,6 +57,13 @@ pub struct OwnedOutput {
     pub script: String,
     pub spent: bool,
     pub spent_by: Option<String>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Recipient {
+    pub address: String, // either old school or silent payment
+    pub amount: u64,
+    pub nb_outputs: u32 // if address is not SP, only 1 is valid
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -163,6 +201,110 @@ impl SpClient {
     pub fn get_scan_key(&self) -> SecretKey {
         self.scan_sk.clone()
     }
+
+    pub fn create_new_psbt(inputs: Vec<OwnedOutput>, recipients: Vec<Recipient>) -> Result<Psbt> {
+        let mut network: Option<Network> = None;
+        let mut tx_in: Vec<bitcoin::TxIn> = vec![];
+        let mut inputs_data: Vec<(ScriptBuf, u64, Scalar)> = vec![];
+
+        for i in inputs {
+            tx_in.push(TxIn { 
+                previous_output: bitcoin::OutPoint::from_str(&i.txoutpoint)?,
+                script_sig: ScriptBuf::new(), 
+                sequence: bitcoin::Sequence::MAX, 
+                witness: bitcoin::Witness::new()
+            });
+
+            let scalar = Scalar::from_be_bytes(FromHex::from_hex(&i.tweak)?)?;
+
+            inputs_data.push((ScriptBuf::from_hex(&i.script)?, i.amount, scalar));
+        }
+
+        // Since we don't have access to private materials for now we use a NUMS key as a placeholder 
+        let placeholder_key = bitcoin::XOnlyPublicKey::from_str(NUMS)?.dangerous_assume_tweaked();
+
+        let _outputs: Result<Vec<bitcoin::TxOut>> = recipients.iter()
+            .map(|o| {
+                let address: Address;
+
+                match SilentPaymentAddress::try_from(o.address.as_str()) {
+                    Ok(sp_address) => {
+                        let address_network = if sp_address.is_testnet() { Network::Testnet } else { Network::Bitcoin };
+
+                        if let Some(network) = network {
+                            if network != address_network { return Err(Error::msg(format!("Wrong network for address {}", sp_address)))}
+                        } else {
+                            network = Some(address_network);
+                        }
+
+                        address = Address::from_script(&ScriptBuf::new_p2tr_tweaked(placeholder_key), address_network).unwrap();
+                    },
+                    Err(_) => {
+                        let unchecked_address = Address::from_str(&o.address)?; // TODO: handle better garbage string
+
+                        if let Some(network) = network {
+                            if network != *unchecked_address.network() { return Err(Error::msg(format!("Wrong network for address {}", unchecked_address.assume_checked())))}
+                        } else {
+                            network = Some(*unchecked_address.network());
+                        }
+
+                        address = unchecked_address.assume_checked();
+                    },
+                }
+
+                Ok(TxOut {
+                    value: Amount::from_sat(o.amount),
+                    script_pubkey: address.script_pubkey()
+                })
+            })
+            .collect();
+
+        let outputs = _outputs?;
+
+        let tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: tx_in,
+            output: outputs
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(tx)?;
+
+        // Add the witness utxo to the input in psbt
+        for (i, input_data) in inputs_data.iter().enumerate() {
+            let (script_pubkey, value, tweak) = input_data;
+            let witness_txout = TxOut {
+                value: Amount::from_sat(*value),
+                script_pubkey: script_pubkey.clone()
+            };
+            let mut psbt_input = Input { witness_utxo: Some(witness_txout), ..Default::default() };
+            psbt_input.proprietary.insert(raw::ProprietaryKey {
+                prefix: PSBT_SP_PREFIX.as_bytes().to_vec(),
+                subtype: PSBT_SP_SUBTYPE,
+                key: PSBT_SP_TWEAK_KEY.as_bytes().to_vec()
+            }, tweak.to_be_bytes().to_vec());
+            psbt.inputs[i] = psbt_input;
+        }
+        
+        for (i, recipient) in recipients.iter().enumerate() {
+            if let Ok(sp_address) = SilentPaymentAddress::try_from(recipient.address.as_str()) {
+                // Add silentpayment address to the output
+                let mut psbt_output = Output { ..Default::default() };
+                psbt_output.proprietary.insert(raw::ProprietaryKey {
+                    prefix: PSBT_SP_PREFIX.as_bytes().to_vec(),
+                    subtype: PSBT_SP_SUBTYPE,
+                    key: PSBT_SP_ADDRESS_KEY.as_bytes().to_vec()
+                }, serialize(&sp_address.to_string()));
+                psbt.outputs[i] = psbt_output;
+            } else {
+                // Regular address, we don't need to add more data
+                continue;
+            }
+        }
+
+        Ok(psbt)
+    }
+
 }
 
 pub fn derive_keys_from_mnemonic(

--- a/src/spclient.rs
+++ b/src/spclient.rs
@@ -256,6 +256,67 @@ impl SpClient {
         Ok(())
     }
 
+    pub fn set_fees(psbt: &mut Psbt, fee_rate: u32, payer: String) -> Result<()> {
+        let payer_vouts: Vec<u32> = match SilentPaymentAddress::try_from(payer.clone()) {
+            Ok(sp_address) => {
+                psbt.outputs.iter().enumerate()
+                    .filter_map(|(i, o)| {
+                        if let Some(value) = o.proprietary.get(&raw::ProprietaryKey {
+                            prefix: PSBT_SP_PREFIX.as_bytes().to_vec(),
+                            subtype: PSBT_SP_SUBTYPE,
+                            key: PSBT_SP_ADDRESS_KEY.as_bytes().to_vec()
+                        }) {
+                            let candidate = SilentPaymentAddress::try_from(deserialize::<String>(&value).unwrap()).unwrap();
+                            if sp_address == candidate {Some(i as u32)} else {None}
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            },
+            Err(_) => {
+                let address = Address::from_str(&payer)?;
+                let spk = address.assume_checked().script_pubkey();
+                psbt.unsigned_tx.output.iter().enumerate()
+                    .filter_map(|(i, o)| {
+                        if o.script_pubkey == spk { Some(i as u32)} else {None}
+                    })
+                    .collect() // Actually we should have only one output for normal address
+            },
+        };
+
+        if payer_vouts.is_empty() {return Err(Error::msg("Payer is not part of this transaction"))}
+
+        // check against the total amt in inputs
+        let total_input_amt: u64 = psbt.iter_funding_utxos().try_fold(0u64, |sum, utxo_result| {
+            utxo_result.map(|utxo| sum + utxo.value.to_sat())
+        })?;
+
+        // total amt in outputs should be equal
+        let total_output_amt: u64 = psbt.unsigned_tx.output.iter().fold(0, |sum, add| sum + add.value.to_sat());
+        
+        if total_input_amt != total_output_amt {
+            return Err(Error::msg("Total inputs/outputs amount is not the same"));
+        }
+
+        // now compute the size of the tx
+        let fake = Self::sign_psbt_fake(psbt);
+        let vsize = fake.vsize();
+
+        // absolut amount of fees
+        let fee_amt: u64 = (fee_rate * vsize as u32).into();
+
+        // now deduce the fees from one of the payer outputs
+        let mut rng = bip39::rand::thread_rng();
+        if let Some(deduce_from) = payer_vouts.choose(&mut rng) {
+            let output = &mut psbt.unsigned_tx.output[*deduce_from as usize];
+            let old_value = output.value;
+            output.value = old_value - Amount::from_sat(fee_amt);
+        } else {return Err(Error::msg("no payer vout"))}
+
+        Ok(())
+    }
+
     pub fn create_new_psbt(inputs: Vec<OwnedOutput>, recipients: Vec<Recipient>) -> Result<Psbt> {
         let mut network: Option<Network> = None;
         let mut tx_in: Vec<bitcoin::TxIn> = vec![];
@@ -408,6 +469,21 @@ impl SpClient {
         };
         let msg = Message::from_digest(sighash.into_32());
         Ok((msg, hash_ty.into()))
+    }
+
+    // Sign a transaction with garbage, used for easier fee estimation
+    fn sign_psbt_fake(psbt: &Psbt) -> Transaction {
+        let mut fake_psbt = psbt.clone();
+
+        let fake_sig = [1u8;64];
+
+        for i in fake_psbt.inputs.iter_mut() {
+            i.tap_key_sig = Some(Signature::from_slice(&fake_sig).unwrap());
+        }
+
+        Self::finalize_psbt(&mut fake_psbt).unwrap();
+        let tx = fake_psbt.extract_tx().expect("Invalid fake tx");
+        tx
     }
 
     pub fn sign_psbt(


### PR DESCRIPTION
Rewriting of the spending of the previous iteration, slightly enhanced as it now supports multiple inputs/outputs in a transaction.
Serious limitation: the total amount of outputs has to match exactly total amount of inputs, as we don't handle change yet.
Works with Sosthene00/donationwallet@d38db10b7c2254737fd1190fca5da01af5d53a7a