### PR TITLE
Fix `!commands.is_empty()` assert faiure: Use forked dependency of nakamoto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 flutter_rust_bridge = "1"
-nakamoto = { git = "https://github.com/cloudhead/nakamoto", branch = "master" }
+nakamoto = { git = "https://github.com/cygnet3/nakamoto", branch = "master" }
 silentpayments = { git = "https://github.com/cygnet3/rust-silentpayments", branch = "master" }
 lazy_static = "1.4"
 electrum-client = { git = "https://github.com/cygnet3/rust-electrum-client", branch = "sp_tweaks" }


### PR DESCRIPTION
The forked dependency currently also includes the commit from this PR: https://github.com/cloudhead/nakamoto/pull/136
This is needed to avoid crashing on an assertion that seems to be fairly common.