### PR TITLE
sleep for 2 seconds after broadcasting

### DIFF
--- a/src/nakamotoclient.rs
+++ b/src/nakamotoclient.rs
@@ -440,5 +440,7 @@ pub fn broadcast_transaction(mut handle: Handle<Waker>, tx: Transaction) -> Resu
 
     handle.submit_transaction(tx)?;
 
+    sleep(Duration::from_secs(2)); // this should be enough
+
     Ok(txid)
 }


### PR DESCRIPTION
The problem was that our function was returning immediately, leaving no time to the peers to request the new transaction with `getdata`.

Closes https://github.com/cloudhead/nakamoto/issues/154